### PR TITLE
Add foodbank centres

### DIFF
--- a/get_foodbank_details_and_write_to_file.py
+++ b/get_foodbank_details_and_write_to_file.py
@@ -36,18 +36,17 @@ trimmed_response_string = ast.literal_eval(trimmed_response_string) # Interrogat
 number_of_foodbanks = 0 # Including nonconforming ones
 number_of_nonconforming_foodbanks = 0 # A.K.A. "poorly" or "non-standard" food banks. Their website doesn't work, or are different to the usual model.
 
-# For MVP, ignore foodbank centres. 
-## TODO Add foodbank centres, as there are quite a few.
-
 # Create a dictionary, with each foodbank name as a key to its own dictionary object
 # {address, latitude, longitude, website, donate_food_url, food needed (only populated if we successfully got this information), error (only populated if there was a problem getting the information)}
 dictionary_of_foodbanks_and_information = {}
 
 for foodbank in trimmed_response_string:
+	if (foodbank['foodbank_information']['name'][0] == "B"): ## these 2 lines just for debugging
+		break
 	number_of_foodbanks += 1
 	print(foodbank['foodbank_information']['name'])
 	if (not foodbank['foodbank_information']['website']): # If this foodbank doesn't have a website, add it, but without website or items needed info
-		dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : "", "error" : "No website given by master list"}
+		dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : "", "error" : "No website given by master list", "location_type" : "foodbank"}
 		number_of_nonconforming_foodbanks += 1
 	else:
 		if (foodbank['foodbank_information']['website'][-1] == "/"): # Handle the URL, whether its given with a trailing slash or not
@@ -59,12 +58,47 @@ for foodbank in trimmed_response_string:
 		if type(items_needed_by_this_foodbank) == str: # If an error (string) was returned for this foodbank, instead of a list of items, record the foodbank with this information
 			number_of_nonconforming_foodbanks += 1			
 			if (items_needed_by_this_foodbank == "Request failed. Likely an SSL certificate error"):
-				dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : "", "error" : items_needed_by_this_foodbank} # Like the other cases of errors, but in this case we hide the website because there might be a security issue
+				dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : "", "error" : items_needed_by_this_foodbank, "location_type" : "foodbank"} # Like the other cases of errors, but in this case we hide the website because there might be a security issue
 			else:
-				dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "error" : items_needed_by_this_foodbank} # Don't populate items needed as we don't know what they are.
+				dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "error" : items_needed_by_this_foodbank, "location_type" : "foodbank"} # Don't populate items needed as we don't know what they are.
 		if type(items_needed_by_this_foodbank) == list:
-			dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "items_needed" : items_needed_by_this_foodbank} # Add this foodbank's information to the dictionary of foodbanks, as a dictionary itself
-		time.sleep(10) # Avoid hammering the server too aggressively.
+			dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']] = {"address" : foodbank['foodbank_information']['geolocation']['address'], "latitude" : foodbank['foodbank_information']['geolocation']['lat'], "longitude" : foodbank['foodbank_information']['geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "items_needed" : items_needed_by_this_foodbank, "location_type" : "foodbank"} # Add this foodbank's information to the dictionary of foodbanks, as a dictionary itself
+	if (foodbank['foodbank_centre'] != False): # If the foodbank has child foodbank centres
+		# It looks like items needed and website are the same as the overall foodbank.
+		# Its name, telephone number, opening times, and various address values, are specific
+		dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'] =  [] # Initialise empty list, to contain names of child foodbank centres
+		for foodbank_centre in foodbank['foodbank_centre']:
+			if (('foodbank_name' in foodbank_centre) and ('address' in foodbank_centre['centre_geolocation']) and ('lat' in foodbank_centre['centre_geolocation']) and ('lng' in foodbank_centre['centre_geolocation'])): # Check that all the expected values are present for this foodbank centre
+				if type(items_needed_by_this_foodbank) == str: # As above. If a foodbank centre's child foodbank has an error or no website, store it differently.
+					number_of_nonconforming_foodbanks += 1			
+					if (items_needed_by_this_foodbank == "Request failed. Likely an SSL certificate error"):
+						if (foodbank_centre['foodbank_name'] in dictionary_of_foodbanks_and_information): # If the foodbank centre name is the same as an existing foodbank name, append 'foodbank centre' to the end. To avoid a key clash 
+							dictionary_of_foodbanks_and_information[foodbank_centre['foodbank_name'] + ' foodbank centre'] = {"address" : foodbank_centre['centre_geolocation']['address'], "latitude" : foodbank_centre['centre_geolocation']['lat'], "longitude" : foodbank_centre['centre_geolocation']['lng'], "website" : "", "error" : items_needed_by_this_foodbank,  "location_type" : "foodbank_centre", "parent_foodbank" : foodbank['foodbank_information']['name']}
+							dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'].append(foodbank_centre['foodbank_name'] + " foodbank centre") # Record this foodbank centre as a child in the entry for its parent foodbank
+						else:
+							dictionary_of_foodbanks_and_information[foodbank_centre['foodbank_name']] = {"address" : foodbank_centre['centre_geolocation']['address'], "latitude" : foodbank_centre['centre_geolocation']['lat'], "longitude" : foodbank_centre['centre_geolocation']['lng'], "website" : "", "error" : items_needed_by_this_foodbank, "location_type" : "foodbank_centre", "parent_foodbank" : foodbank['foodbank_information']['name']}
+							dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'].append(foodbank_centre['foodbank_name']) # Record this foodbank centre as a child in the entry for its parent foodbank
+					else:
+						if (foodbank_centre['foodbank_name'] in dictionary_of_foodbanks_and_information):
+							dictionary_of_foodbanks_and_information[foodbank_centre['foodbank_name']  + ' foodbank centre'] = {"address" : foodbank_centre['centre_geolocation']['address'], "latitude" : foodbank_centre['centre_geolocation']['lat'], "longitude" : foodbank_centre['centre_geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "error" : items_needed_by_this_foodbank, "location_type" : "foodbank_centre", "parent_foodbank" : foodbank['foodbank_information']['name']}					
+							dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'].append(foodbank_centre['foodbank_name']  + " foodbank centre")
+						else:
+							dictionary_of_foodbanks_and_information[foodbank_centre['foodbank_name']] = {"address" : foodbank_centre['centre_geolocation']['address'], "latitude" : foodbank_centre['centre_geolocation']['lat'], "longitude" : foodbank_centre['centre_geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "error" : items_needed_by_this_foodbank, "location_type" : "foodbank_centre", "parent_foodbank" : foodbank['foodbank_information']['name']}					
+							dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'].append(foodbank_centre['foodbank_name'])
+				if type(items_needed_by_this_foodbank) == list:
+					if (foodbank_centre['foodbank_name'] in dictionary_of_foodbanks_and_information):
+						dictionary_of_foodbanks_and_information[foodbank_centre['foodbank_name'] + ' foodbank centre'] = {"address" : foodbank_centre['centre_geolocation']['address'], "latitude" : foodbank_centre['centre_geolocation']['lat'], "longitude" : foodbank_centre['centre_geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "items_needed" : items_needed_by_this_foodbank, "location_type" : "foodbank_centre", "parent_foodbank" : foodbank['foodbank_information']['name']}					
+						dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'].append(foodbank_centre['foodbank_name'] + " foodbank centre")
+					else:
+						dictionary_of_foodbanks_and_information[foodbank_centre['foodbank_name']] = {"address" : foodbank_centre['centre_geolocation']['address'], "latitude" : foodbank_centre['centre_geolocation']['lat'], "longitude" : foodbank_centre['centre_geolocation']['lng'], "website" : foodbank['foodbank_information']['website'], "items_needed" : items_needed_by_this_foodbank, "location_type" : "foodbank_centre", "parent_foodbank" : foodbank['foodbank_information']['name']}					
+						dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'].append(foodbank_centre['foodbank_name'])
+			else: #If we don't have the all the expected pieces of information about this foodbank's child foodbank centres
+				number_of_nonconforming_foodbanks += 1
+				continue ## If this foodbank centre has doesn't have all the information we need, skip it. TODO think of what we might do here.
+		#print(dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'])
+	else:
+		dictionary_of_foodbanks_and_information[foodbank['foodbank_information']['name']]['foodbank_centres'] =  False # Record that this foodbank does not have child foodbank centres
+	time.sleep(1) # Avoid hammering the server too aggressively.
 	
 print("Finished iterating through the list of foodbanks")
 print("Number of foodbanks in total: " + str(number_of_foodbanks))

--- a/get_foodbank_details_and_write_to_file.py
+++ b/get_foodbank_details_and_write_to_file.py
@@ -41,8 +41,8 @@ number_of_nonconforming_foodbanks = 0 # A.K.A. "poorly" or "non-standard" food b
 dictionary_of_foodbanks_and_information = {}
 
 for foodbank in trimmed_response_string:
-	if (foodbank['foodbank_information']['name'][0] == "B"): ## these 2 lines just for debugging
-		break
+	#if (foodbank['foodbank_information']['name'][0] == "B"): ## We work through foodbanks alphabetically. Stop at the start of the given letter. For debugging
+	#	break
 	number_of_foodbanks += 1
 	print(foodbank['foodbank_information']['name'])
 	if (not foodbank['foodbank_information']['website']): # If this foodbank doesn't have a website, add it, but without website or items needed info


### PR DESCRIPTION
Most foodbank have 'foodbank centres' associated with them. They don't have independent lists of items needed, or independent websites. 

I've included them with the assumption that they are places that people could go to donate items, but this may be incorrect. If they turn out to not be worth returning to users, server return values could easily be set to exclude them.

The following fields are added to the dictionary associated with a given foodbank or foodbank centre:

location_type: "foodbank" or "foodbank_centre"

foodbank_centres: only displayed if it's a foodbank. Will be a list of the names of child foodbank centres OR False if it has no children.

parent_foodbank: Only present if it's a foodbank_centre. String of parent foodbank.

There's an edge case whereby a foodbank and a foodbank centre might occasionally have the same name. In these instances, we add to the end of the foodbank centre's name so that we don't have a clash.